### PR TITLE
feat(ct-36): Orders Repository

### DIFF
--- a/di-container.js
+++ b/di-container.js
@@ -3,7 +3,12 @@ const container = awilix.createContainer();
 const database = require('./models/database/firebase-connection');
 const databaseHelper = require('./models/database/firebase-helper');
 
-container.loadModules([], {
+container.loadModules([
+  // This pattern helps automatically load repositories into the DI container
+  [
+    './**/*-repository.js',
+  ],
+], {
   cwd: __dirname,
   formatName: 'camelCase',
 });

--- a/models/database/firebase-helper.js
+++ b/models/database/firebase-helper.js
@@ -26,7 +26,7 @@ class FirebaseHelper {
    * @returns {object}
    */
   async saveEntity({model, newEntity}) {
-    const pushId = model.push(newEntity).key();
+    const pushId = model.push(newEntity).key;
     return {
       ...newEntity,
       id: pushId,

--- a/models/orders-repository.js
+++ b/models/orders-repository.js
@@ -1,0 +1,35 @@
+/**
+ * The order repository (following the repository pattern)
+ * is a DAL component that is used to access the persistence layer,
+ * and perform operations on it.
+ * https://deviq.com/repository-pattern/
+ * @module OrdersRepository
+ */
+class OrdersRepository {
+  /**
+   * @module constructor
+   * @param {object} databaseHelper - The database helper class,
+   * used to make database operations like an ORM.
+   */
+  constructor({databaseHelper}) {
+    const collectionName = 'orders';
+    this._databaseHelper = databaseHelper;
+    this._orderModel = databaseHelper.getModel(collectionName);
+  }
+
+  /**
+   *
+   * @param {object}
+   *  - newOrder - The information about orders to save.
+   * @return {Promise<order>} - Returns a promise containing,
+   * an object with a new pushId
+   */
+  createOrder({newOrder}) {
+    return this._databaseHelper.saveEntity({
+      model: this._orderModel,
+      newEntity: newOrder,
+    });
+  }
+}
+
+module.exports = OrdersRepository;


### PR DESCRIPTION
The PR contains code for the orderRepository which is a DAL object following the repository pattern. The orderRepository will be used to perform all data persistence functions for the orders entity. The PR also adds a pattern to the DI container to help  retrieve any repository files.

- Create a new Orders repository class
- Implement a create order function in the order repository
- Fix bug with retrieving the pushId as a function instead of a property
- Add a pattern for repositories to the DI container

https://trello.com/c/tzTXQcE6/36-data-access-layer-create-repository-function-to-handle-creation-of-new-orders