### PR TITLE
feat(ct-33-validator): Order validator

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const indexRouter = require('./routes/index');
 const {validateEnvironmentVariables} = require('./config');
 const debug = require('debug')('backend-task:server');
 const loadAppConnections = require('./loaders');
-const DI = require('./di-container');
 
 module.exports = async () => {
   try {

--- a/di-container.js
+++ b/di-container.js
@@ -8,6 +8,10 @@ container.loadModules([
   [
     './**/*-repository.js',
   ],
+  // This pattern loads validation functions used in validating user data
+  [
+    './**/*-validator.js',
+  ],
 ], {
   cwd: __dirname,
   formatName: 'camelCase',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2814,6 +2814,11 @@
         }
       }
     },
+    "google-libphonenumber": {
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.13.tgz",
+      "integrity": "sha512-USnpjJkD8St+wyshy154lF74JeauNCd8vrcusSlWjSFWitXzl7ZSuCunA/XxeVLqBv6DShrSfFMYdwGZ7x4hOw=="
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3828,6 +3833,14 @@
         "@sideway/address": "^4.1.0",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "joi-phone-number": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/joi-phone-number/-/joi-phone-number-5.0.0.tgz",
+      "integrity": "sha512-TTo7JtVAe/OHxuKHnmO+/jR6aKVUxHU2PgRotryc2tS1YN95/OgSn3tT3Ipzw5mjyzeyjb/V0Sk6L8gUq2U/9w==",
+      "requires": {
+        "google-libphonenumber": "3.2.13"
       }
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "helmet": "^4.2.0",
     "http-errors": "~1.6.3",
     "joi": "^17.3.0",
+    "joi-phone-number": "^5.0.0",
     "morgan": "~1.9.1",
     "winston": "^3.3.3"
   },

--- a/services/orders/order-validator.js
+++ b/services/orders/order-validator.js
@@ -1,0 +1,36 @@
+const Joi = require('joi');
+/**
+ * Joi does not have a built in phone number validation rule.
+ * So this npm package from SalesFire provides that as an extension.
+ * https://www.npmjs.com/package/joi-phone-number
+ */
+const JoiExtended = Joi.extend(require('joi-phone-number'));
+
+/**
+ * This closure is how the dependency injection library injects into the function.
+ * The outer function will be used by the DI tool,
+ * while the second function is the validator.
+ * @return {Function}
+ */
+module.exports = () => (data) => {
+  const address = Joi.object({
+    city: Joi.string().required(),
+    country: Joi.string().required(),
+    street: Joi.string().required(),
+    zip: Joi.number().required(),
+  });
+  const customer = Joi.object({
+    email: Joi.string().email().required(),
+    name: Joi.string().required(),
+    phone: JoiExtended.string().phoneNumber(),
+    // Joi.string().length(14).regex(/^\d+$/),
+  });
+  const schema = Joi.object({
+    address,
+    bookingDate: Joi.date().timestamp(),
+    customer,
+    title: Joi.string().required(),
+  });
+
+  return schema.validateAsync(data);
+};


### PR DESCRIPTION
This PR contains code to help validate order information received from the user. The Joi library used for validating data does not contain a way to validate phone numbers so I also installed a library called [https://www.npmjs.com/package/joi-phone-number](joi-phone-number) and used that to validate phone numbers form the customer node of the order object.

- Implementation of a function to help validate an order
- Installed joi-phone-number package
- Add a new autoload rule to the DI to load validators

https://trello.com/c/V5oHElHJ/33-app-layer-implement-service-function-for-creating-a-new-order